### PR TITLE
Only set up homebrew site functions when `brew` is found

### DIFF
--- a/zsh-brew.plugin.zsh
+++ b/zsh-brew.plugin.zsh
@@ -15,21 +15,29 @@ if (( ! $+commands[brew] )); then
     done
 
     eval "$("$BREW_PATH" shellenv)"
+    # Tidy up environment
+    unset DEFAULT_BREW_PATHS
+    unset BREW_PATH
 fi
 
-# If the 'HOMEBREW_PREFIX' environment variable is not populated then
-# request the prefix from 'brew' and populate
-if [[ -z "$HOMEBREW_PREFIX" ]]; then
-    export HOMEBREW_PREFIX="$(brew --prefix)"
-fi
+if (( $+commands[brew] )); then
+    # If the 'HOMEBREW_PREFIX' environment variable is not populated then
+    # request the prefix from 'brew' and populate
 
-# Add Homebrew 'site-functions directory to the FPATH
-local HOMEBREW_SITE_FUNCTIONS="$HOMEBREW_PREFIX/share/zsh/site-functions"
+    if [[ -z "$HOMEBREW_PREFIX" ]]; then
+        export HOMEBREW_PREFIX="$(brew --prefix)"
+    fi
 
-if [[ -d "$HOMEBREW_SITE_FUNCTIONS" ]]; then
-    typeset -TUx FPATH fpath
-    fpath=("$HOMEBREW_SITE_FUNCTIONS" $fpath)
+    # Add Homebrew 'site-functions directory to the FPATH
+    local HOMEBREW_SITE_FUNCTIONS="$HOMEBREW_PREFIX/share/zsh/site-functions"
 
-    autoload -Uz compinit
-    compinit
+    if [[ -d "$HOMEBREW_SITE_FUNCTIONS" ]]; then
+        typeset -TUx FPATH fpath
+        fpath=("$HOMEBREW_SITE_FUNCTIONS" $fpath)
+        autoload -Uz compinit
+        compinit
+    fi
+    # More tidying up
+    unset HOMEBREW_PREFIX
+    unset HOMEBREW_SITE_FUNCTIONS
 fi

--- a/zsh-brew.plugin.zsh
+++ b/zsh-brew.plugin.zsh
@@ -15,9 +15,6 @@ if (( ! $+commands[brew] )); then
     done
 
     eval "$("$BREW_PATH" shellenv)"
-    # Tidy up environment
-    unset DEFAULT_BREW_PATHS
-    unset BREW_PATH
 fi
 
 if (( $+commands[brew] )); then
@@ -37,7 +34,4 @@ if (( $+commands[brew] )); then
         autoload -Uz compinit
         compinit
     fi
-    # More tidying up
-    unset HOMEBREW_PREFIX
-    unset HOMEBREW_SITE_FUNCTIONS
 fi


### PR DESCRIPTION
- Make setting and using `HOMEBREW_SITE_FUNCTIONS` only happen when `brew` was found, either in `$PATH` or by searching through `DEFAULT_BREW_PATHS`.