### PR TITLE
Update README.md for information on plugin order

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ autoload -Uz compinit
 compinit -d "${ZDOTDIR:-$HOME}/.zcompdump"
 ```
 
+If you do not have the brew install directory already within your `$PATH`, be sure to include this plugin before any additional plugins that use applications installed via brew (e.g. eza, starship, etc.).
+
 ## Prerequisite Checks
 A check will be performed to verify that `brew` has been installed:
 


### PR DESCRIPTION
This change adds a notice on the install procedure to place the zsh-brew plugin in the appropriate order within the `.zshrc` file to ensure applications installed via brew can be loaded with their respective plugins.