### PR TITLE
Run shellenv even if brew is already in path

### DIFF
--- a/zsh-brew.plugin.zsh
+++ b/zsh-brew.plugin.zsh
@@ -18,6 +18,9 @@ if (( ! $+commands[brew] )); then
     if [[ ! -z "$BREW_PATH" ]]; then
         source <("$BREW_PATH" shellenv)
     fi
+else
+    # Ensure that shell environment is fully configured
+    source <(brew shellenv)
 fi
 
 if (( $+commands[brew] )); then


### PR DESCRIPTION
In case `brew` is already in path (e.g. `/usr/local/bin` is in `/private/etc/paths` on macOS), it still makes sense to apply `brew shellenv` to ensure that `sbin` is also in path and environment variables are set.